### PR TITLE
.3631064758624387:ab59040028c731f63538c55320f4b350_69ddffa456f8d3bae7ce3c02.69de49b2d0718748036dbf5e.69de49b230533e2149b46a3a:Trae CN.T(2026/4/14 22:05:38)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1713,6 +1714,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2091,6 +2093,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2940,6 +2943,7 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
       "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.2.4",
         "ansi-escapes": "^7.3.0",
@@ -3606,6 +3610,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3778,6 +3783,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4434,6 +4440,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4539,6 +4546,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4909,6 +4917,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.3.0-canary-1b45e243-20260402.tgz",
       "integrity": "sha512-CUTHdpLPSvcJovRhEegguvA6z5d76SoR/CXY32EnDoB22ScDV/PYjvKzAmxwRooY2VcZHzpD3WfcSgHRjocbPA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -126,6 +126,7 @@ export interface GeneralConfig {
   codexHome: string;
   stateDir: string;
   uiLanguage: UiLanguage;
+  sessionSortOrder?: SortOrder;
 }
 
 export interface AiConfig {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import { usePaneLayoutState } from "./app-shell/usePaneLayoutState.js";
 import { useThemePreference } from "./app-shell/useThemePreference.js";
 import { copyTextToClipboard } from "./clipboard.js";
 import { normalizeUiLanguage, t } from "./i18n.js";
+import { normalizeSessionSortOrder } from "./settings-model.js";
 import { SessionBrowser } from "./SessionBrowser.js";
 import { ALL_WORKSPACES_ID, useControlDeckState } from "./useControlDeckState.js";
 import { AppViewTransition, addAppTransitionType } from "./view-transitions.js";
@@ -65,6 +66,7 @@ export function App() {
   const [requeuePanelLoaded, setRequeuePanelLoaded] = React.useState(() => state.tab === "requeue");
   const [daemonPanelLoaded, setDaemonPanelLoaded] = React.useState(() => state.tab === "daemon");
   const uiLanguage = normalizeUiLanguage(state.configView);
+  const sortOrder = normalizeSessionSortOrder(state.configView);
   const tt = (key: Parameters<typeof t>[1]) => t(uiLanguage, key);
   const previewApplyCount =
     state.preview?.items.filter((item) => item.status === "apply").length ?? 0;
@@ -195,6 +197,7 @@ export function App() {
               showHiddenTranscript={state.showHiddenTranscript}
               error={state.error}
               uiLanguage={uiLanguage}
+              sortOrder={sortOrder}
               onToggleShowHiddenTranscript={state.setShowHiddenTranscript}
               onSearchChange={state.setSearch}
               onRefresh={() => void state.refreshSessions()}

--- a/packages/web/src/SessionBrowser.tsx
+++ b/packages/web/src/SessionBrowser.tsx
@@ -5,7 +5,7 @@ import { SessionListPane } from "./features/sessions/SessionListPane.js";
 import type { UiLanguage } from "./i18n.js";
 import { t } from "./i18n.js";
 import { TranscriptPanel } from "./TranscriptPanel.js";
-import type { SessionDetail, SessionSummary } from "./types.js";
+import type { SessionDetail, SessionSummary, SortOrder } from "./types.js";
 import { AppViewTransition } from "./view-transitions.js";
 
 const SESSION_PANE_MIN_WIDTH = 320;
@@ -28,6 +28,7 @@ export function SessionBrowser(props: {
   showHiddenTranscript: boolean;
   error: string | null;
   uiLanguage: UiLanguage;
+  sortOrder: SortOrder;
   onToggleShowHiddenTranscript: (value: boolean) => void;
   onSearchChange: (value: string) => void;
   onRefresh: () => void;
@@ -118,6 +119,7 @@ export function SessionBrowser(props: {
         sessionPaneCollapsed={props.sessionPaneCollapsed}
         sessions={props.sessions}
         uiLanguage={props.uiLanguage}
+        sortOrder={props.sortOrder}
       />
 
       {!props.sessionPaneCollapsed && !props.focusMode ? (

--- a/packages/web/src/browser-utils.ts
+++ b/packages/web/src/browser-utils.ts
@@ -1,6 +1,6 @@
 import type { UiLanguage } from "./i18n.js";
 import { formatUiWhen, timeGroupLabel } from "./i18n.js";
-import type { SessionDetail, SessionSummary } from "./types.js";
+import type { SessionDetail, SessionSummary, SortOrder } from "./types.js";
 
 export function formatWhen(value: string | undefined | null, language: UiLanguage): string {
   return formatUiWhen(value, language);
@@ -72,6 +72,7 @@ function getTimeGroup(value?: string): TimeGroupLabel {
 export function groupSessionsByTime(
   sessions: SessionSummary[],
   language: UiLanguage,
+  sortOrder: SortOrder = "desc",
 ): Array<{ label: string; items: SessionSummary[] }> {
   const groups = new Map<TimeGroupLabel, SessionSummary[]>();
   for (const label of TIME_GROUP_ORDER) {
@@ -82,7 +83,17 @@ export function groupSessionsByTime(
     groups.get(getTimeGroup(session.updatedAt))?.push(session);
   }
 
-  return TIME_GROUP_ORDER.map((label) => ({
+  for (const group of groups.values()) {
+    group.sort((a, b) => {
+      const timeA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+      const timeB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+      return sortOrder === "desc" ? timeB - timeA : timeA - timeB;
+    });
+  }
+
+  const groupOrder = sortOrder === "desc" ? TIME_GROUP_ORDER : [...TIME_GROUP_ORDER].reverse();
+
+  return groupOrder.map((label) => ({
     label: timeGroupLabel(label, language),
     items: groups.get(label) ?? [],
   })).filter((group) => group.items.length > 0);

--- a/packages/web/src/features/sessions/SessionListPane.tsx
+++ b/packages/web/src/features/sessions/SessionListPane.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../browser-utils.js";
 import type { UiLanguage } from "../../i18n.js";
 import { sessionStatusLabel, t } from "../../i18n.js";
-import type { SessionSummary } from "../../types.js";
+import type { SessionSummary, SortOrder } from "../../types.js";
 import { addAppTransitionType } from "../../view-transitions.js";
 
 const SESSION_CONTEXT_MENU_WIDTH = 220;
@@ -25,6 +25,7 @@ export function SessionListPane(props: {
   loadingSessions: boolean;
   error: string | null;
   uiLanguage: UiLanguage;
+  sortOrder: SortOrder;
   onSearchChange: (value: string) => void;
   onRefresh: () => void;
   onSelectSession: (threadId: string) => void;
@@ -42,8 +43,8 @@ export function SessionListPane(props: {
   const searchCommitTimerRef = React.useRef<number | null>(null);
   const searchComposingRef = React.useRef(false);
   const groupedSessions = React.useMemo(
-    () => groupSessionsByTime(props.sessions, props.uiLanguage),
-    [props.sessions, props.uiLanguage],
+    () => groupSessionsByTime(props.sessions, props.uiLanguage, props.sortOrder),
+    [props.sessions, props.uiLanguage, props.sortOrder],
   );
   const tt = React.useCallback(
     (key: Parameters<typeof t>[1]) => t(props.uiLanguage, key),

--- a/packages/web/src/features/settings/sections/NamingSection.tsx
+++ b/packages/web/src/features/settings/sections/NamingSection.tsx
@@ -386,6 +386,31 @@ export function NamingSection(props: {
               ]}
               value={props.draft.uiLanguage}
             />
+            <SelectField
+              label={props.text.tt("defaultSortOrder")}
+              onChange={(value) => {
+                props.updateDraftField("sessionSortOrder", value);
+              }}
+              options={[
+                {
+                  value: "desc",
+                  label: props.text.tt("sortNewestFirst"),
+                  description: props.text.inline(
+                    "最新的会话显示在最前面。",
+                    "Newest sessions appear first.",
+                  ),
+                },
+                {
+                  value: "asc",
+                  label: props.text.tt("sortOldestFirst"),
+                  description: props.text.inline(
+                    "最早的会话显示在最前面。",
+                    "Oldest sessions appear first.",
+                  ),
+                },
+              ]}
+              value={props.draft.sessionSortOrder}
+            />
             <label className="settings-field">
               <span>{props.text.tt("language")}</span>
               <select

--- a/packages/web/src/i18n.ts
+++ b/packages/web/src/i18n.ts
@@ -162,6 +162,9 @@ const COPY = {
     thisMonth: "This Month",
     earlier: "Earlier",
     nA: "n/a",
+    defaultSortOrder: "Default sort order",
+    sortNewestFirst: "Newest first",
+    sortOldestFirst: "Oldest first",
   },
   "zh-CN": {
     allWorkspaces: "全部工作区",
@@ -322,6 +325,9 @@ const COPY = {
     thisMonth: "本月",
     earlier: "更早",
     nA: "无",
+    defaultSortOrder: "默认排序方式",
+    sortNewestFirst: "最新在前",
+    sortOldestFirst: "最早在前",
   },
 } as const;
 

--- a/packages/web/src/settings-model.ts
+++ b/packages/web/src/settings-model.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
-import type { ConfigDocument, ConfigView, ProviderProfile } from "./types.js";
+import type { ConfigDocument, ConfigView, ProviderProfile, SortOrder } from "./types.js";
+
+export type SessionSortOrder = SortOrder;
 
 export type SettingsDraft = {
   uiLanguage: "en-US" | "zh-CN";
@@ -36,6 +38,7 @@ export type SettingsDraft = {
   maintenanceBackupBeforeCompact: boolean;
   providerProfiles: ProviderProfile[];
   selectedProfileId: string;
+  sessionSortOrder: SessionSortOrder;
 };
 
 export type RenameAutoApply = "disabled" | "idle-finalize";
@@ -326,6 +329,7 @@ export function buildDraft(configView: ConfigView): SettingsDraft {
     ),
     providerProfiles,
     selectedProfileId,
+    sessionSortOrder: asString(asRecord(effective.general).sessionSortOrder, "desc") as SessionSortOrder,
   };
 }
 
@@ -368,6 +372,7 @@ export function encodeDraft(draft: SettingsDraft): ConfigDocument {
   return {
     general: {
       uiLanguage: draft.uiLanguage,
+      sessionSortOrder: draft.sessionSortOrder,
     },
     rename: {
       autoApply: draft.renameAutoApply as RenameAutoApply,
@@ -610,4 +615,12 @@ export function summarizeProfileLabel(profile: ProviderProfile): string {
     firstNonEmptyString(profile.displayName, profile.profileId, profile.model, profile.baseUrl) ??
     profile.profileId
   );
+}
+
+export function normalizeSessionSortOrder(configView?: { effectiveConfig?: unknown } | null): SessionSortOrder {
+  const raw = (configView?.effectiveConfig as Record<string, unknown> | undefined)?.general as
+    | Record<string, unknown>
+    | undefined;
+  const value = raw?.sessionSortOrder;
+  return value === "asc" ? "asc" : "desc";
 }

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -24,6 +24,7 @@ export type {
   SessionSummary,
   SessionsResponse,
   SessionTranscriptPage,
+  SortOrder,
   UiLanguage,
   WorkspaceSummary,
 } from "@codexnamer/shared";


### PR DESCRIPTION
实现会话列表按时间排序功能，支持最新在前和最早在前两种排序方式
在设置中添加排序选项，并同步更新相关类型定义和国际化文本

## Summary

Describe the change in a few sentences.

## What changed

- [ ]
- [ ]
- [ ]

## Validation

- [ ] `npm run build`
- [ ] `npm run web:build`
- [ ] `npm test`

## Docs

- [ ] README updated if needed
- [ ] relevant spec/docs updated if needed

## Notes for reviewers

Anything specific you'd like reviewers to focus on.
